### PR TITLE
fix(docs): Pin Tailwind CSS version in Vite installation command

### DIFF
--- a/content/docs/installation/vite.mdx
+++ b/content/docs/installation/vite.mdx
@@ -17,7 +17,7 @@ npm create vite@latest
 ### Add Tailwind CSS
 
 ```bash
-npm install tailwindcss @tailwindcss/vite
+npm install tailwindcss@3.4.1 @tailwindcss/vite
 ```
 
 Replace everything in `src/index.css` with the following:


### PR DESCRIPTION
Pull Request: Update Vite Tailwind CSS Installation Command

🔍 What does this PR do?
This PR updates the Vite installation documentation to explicitly specify version 3.4.1 for the tailwindcss package. This change aims to prevent potential errors that might arise from unintended breaking changes in future major versions of Tailwind CSS, ensuring a more stable installation experience for users.

🛠 Related issue(s)
Closes #59




✅ Checklist

    [x] I have tested my changes locally.

    [x] I have added necessary documentation or updated existing docs.

    [x] My code follows the project style guidelines.

    [x] I have ensured there are no linting or build errors.

    [ ] I have added or updated tests if applicable.

📝 Additional notes
This update aligns the documentation with best practices for package management by pinning a specific version of Tailwind CSS, ensuring consistency and reliability for users following the installation guide. This should help avoid "unwanted errors" as originally discussed in the related issue.

📸 Screenshot
<img width="1102" height="615" alt="Screenshot 2025-07-25 142909" src="https://github.com/user-attachments/assets/c2cfba3d-fdf2-4bcc-ac16-dd57e8c7a5be" />
