### PR TITLE
fix: unresolve motion/react installation docs in interactive-tooltip.mdx

### DIFF
--- a/content/docs/creative/interactive-tooltip.mdx
+++ b/content/docs/creative/interactive-tooltip.mdx
@@ -27,22 +27,22 @@ import { TypeTable } from "fumadocs-ui/components/type-table";
     <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
       <Tab>
         ```bash
-        npm install motion/react react
+        npm install motion react
         ```
       </Tab>
       <Tab>
         ```bash
-        pnpm install motion/react react
+        pnpm install motion react
         ```
       </Tab>
       <Tab>
         ```bash
-        yarn add motion/react react
+        yarn add motion react
         ```
       </Tab>
       <Tab>
         ```bash
-        bun add motion/react react
+        bun add motion react
         ```
       </Tab>
     </Tabs>


### PR DESCRIPTION
motion/react is not a package — it’s just an import path inside the motion package.

**🔍 What does this PR do?**  
Briefly describe the purpose and main changes in this pull request.

**🛠 Related issue(s)**  
Link the issue(s) this PR addresses, if any.

**📸 Screenshot or GIF (if applicable)**  
Attach a screenshot or GIF showing the changes or new feature in action.

**✅ Checklist**  
- [x] I have tested my changes locally.  
- [x] I have added necessary documentation or updated existing docs.  
- [x] My code follows the project style guidelines.  
- [x] I have ensured there are no linting or build errors.  
- [ ] I have added or updated tests if applicable.  

**📝 Additional notes**  
Any other relevant information for the reviewers.
