### PR TITLE
fix: Handle missing GitHub token gracefully and resolve Next.js 15 fumadocs-ui compatibility

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -2,7 +2,7 @@ import { DocsLayout, type DocsLayoutProps } from 'fumadocs-ui/layouts/notebook';
 import type { ReactNode } from 'react';
 import { baseOptions } from '@/app/layout.config';
 import { source } from '@/lib/source';
-import { RootProvider } from 'fumadocs-ui/provider';
+import { RootProvider } from '@/components/shared/root-provider';
 import dynamic from 'next/dynamic';
 import { Banner } from 'fumadocs-ui/components/banner';
 import Link from 'next/link';

--- a/components/shared/root-provider.tsx
+++ b/components/shared/root-provider.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { RootProvider as FumadocsRootProvider } from 'fumadocs-ui/provider';
+import type { ReactNode } from 'react';
+
+interface RootProviderProps {
+  search?: any;
+  children: ReactNode;
+}
+
+export function RootProvider(props: RootProviderProps) {
+  return <FumadocsRootProvider {...props} />;
+}


### PR DESCRIPTION
## Description
Fixes two critical issues preventing local development:

1. **GitHub API 401 errors** - Application crashed when `GITHUB_TOKEN` was not configured
2. **fumadocs-ui export error** - Next.js 15 compatibility issue with `export *` in client boundaries

## Changes Made
- Modified `actions/githubgraphql.ts` to gracefully handle missing GitHub tokens
  - Returns empty data instead of throwing errors
  - Adds console warnings for debugging
  - Improves developer experience for local development

- Created `components/shared/root-provider.tsx` as a client-side wrapper
  - Resolves Next.js 15 client boundary issue with fumadocs-ui
  - Fixes "It's currently unsupported to use 'export *' in a client boundary" error

- Updated `app/docs/layout.tsx` to use the new wrapper component

## Testing
- [x] Application now runs without errors when `GITHUB_TOKEN` is not set
- [x] `/docs` routes load without fumadocs-ui export errors
- [x] Features requiring GitHub API fail gracefully with console warnings

## Related Issues
Fixes issues with local development environment setup for contributors.